### PR TITLE
Fix incorrect departments for BADR and BABED

### DIFF
--- a/ntnuthesis/ntnubachelorthesis.cls
+++ b/ntnuthesis/ntnubachelorthesis.cls
@@ -539,7 +539,7 @@ Use $\backslash$useyear\{<year>\} to set year.
 
 \DeclareOption{BADR}{%
   \renewcommand\nmt@DepartmentNameText{%
-    	\nmt@IIK
+    	\nmt@IDI
 			}
 	\renewcommand\nmt@DegreeNameText{%
         \nmt@BADR
@@ -557,7 +557,7 @@ Use $\backslash$useyear\{<year>\} to set year.
 
 \DeclareOption{BABED}{%
     \renewcommand\nmt@DepartmentNameText{%
-    	\nmt@IIK
+    	\nmt@IDI
 			}
 	\renewcommand\nmt@DegreeNameText{%
         \nmt@BABED


### PR DESCRIPTION
These two was incorrectly set to IIK when they reside at IDI.

Noticed mere days before sending to print :1st_place_medal: 